### PR TITLE
Add mark-all-notifications feature

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -51,4 +51,15 @@ public function getUserNotifications()
 
         return response()->json(['success' => true]);
     }
+
+    public function markAllAsRead()
+    {
+        $user = auth()->user();
+
+        Notification::where('user_id', $user->id)
+            ->where('read', false)
+            ->update(['read' => true]);
+
+        return response()->json(['success' => true]);
+    }
 }

--- a/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -45,6 +45,12 @@ const handleFollowAction = (followerId, action, notifId) => {
         });
     };
 
+    const markAllAsRead = () => {
+        axios.post('/notifications/read-all').then(() => {
+            fetchNotifications();
+        });
+    };
+
     const MenuLink = ({ href, active, icon, children }) => (
         <Link
             href={href}
@@ -248,6 +254,11 @@ const handleFollowAction = (followerId, action, notifId) => {
 
 {showNotifications && (
     <div className="absolute right-0 mt-2 w-80 bg-white border border-gray-200 shadow-lg rounded-md z-50 max-h-96 overflow-y-auto">
+        <div className="flex justify-end p-2 border-b">
+            <button onClick={markAllAsRead} className="text-xs text-blue-600 hover:underline">
+                Mark all as read
+            </button>
+        </div>
         {notifications.length === 0 ? (
             <div className="p-4 text-sm text-gray-500 text-center">
                 {t('No notifications available')}

--- a/resources/js/Layouts/AuthenticatedLayoutAdmin.jsx
+++ b/resources/js/Layouts/AuthenticatedLayoutAdmin.jsx
@@ -36,6 +36,12 @@ export default function AuthenticatedLayout({ header, children }) {
         });
     };
 
+    const markAllAsRead = () => {
+        axios.post('/notifications/read-all').then(() => {
+            fetchNotifications();
+        });
+    };
+
     return (
         <div className="min-h-screen bg-gray-100">
             <nav className="border-b border-gray-100 bg-white">
@@ -77,6 +83,11 @@ export default function AuthenticatedLayout({ header, children }) {
 
                                 {showNotifications && (
                                     <div className="absolute right-0 mt-2 w-80 bg-white border border-gray-200 shadow-lg rounded-md z-50 max-h-96 overflow-y-auto">
+                                        <div className="flex justify-end p-2 border-b">
+                                            <button onClick={markAllAsRead} className="text-xs text-blue-600 hover:underline">
+                                                Mark all as read
+                                            </button>
+                                        </div>
                                         {notifications.length === 0 ? (
                                             <div className="p-4 text-sm text-gray-500 text-center">هیچ نوتیفیکیشنی وجود ندارد</div>
                                         ) : (

--- a/routes/web.php
+++ b/routes/web.php
@@ -90,6 +90,7 @@ Route::middleware('auth')->group(function () {
     Route::post('/follow/{user}/reject', [FollowController::class, 'rejectRequest'])->name('follow.reject');
     Route::get('/notifications', [NotificationController::class, 'getUserNotifications']);
     Route::post('/notifications/read/{id}', [NotificationController::class, 'markAsRead']);
+    Route::post('/notifications/read-all', [NotificationController::class, 'markAllAsRead']);
     Route::post('/username-check', function (Request $request) {
         $request->validate([
             'username' => 'required|string|min:4|max:222',


### PR DESCRIPTION
## Summary
- add `markAllAsRead` controller method
- support `/notifications/read-all` route
- expose button in user & admin layouts to mark all notifications as read

## Testing
- `npm test` *(fails: missing script)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844b9054f108326a135055502d65e10