### PR TITLE
Add block-aware content filtering

### DIFF
--- a/app/Http/Controllers/BlockController.php
+++ b/app/Http/Controllers/BlockController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Block;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class BlockController extends Controller
+{
+    public function block(User $user)
+    {
+        $auth = auth()->user();
+        if ($auth->id === $user->id) {
+            return response()->json(['error' => 'Cannot block yourself'], 422);
+        }
+
+        Block::firstOrCreate([
+            'user_id' => $auth->id,
+            'blocked_id' => $user->id,
+        ]);
+
+        return response()->json(['blocked' => true]);
+    }
+
+    public function unblock(User $user)
+    {
+        $auth = auth()->user();
+        Block::where('user_id', $auth->id)->where('blocked_id', $user->id)->delete();
+        return response()->json(['unblocked' => true]);
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -15,6 +15,7 @@ class DashboardController extends Controller
 {
     $user = auth()->user();
     $followingIds = $user->followings()->pluck('users.id');
+    $blockedIds = $user->blockedIds()->merge($user->blockedByIds());
 
     // پست‌های کاربران فالو شده (تب Followed)
     $followedPosts = Post::with([
@@ -24,6 +25,7 @@ class DashboardController extends Controller
             'repost' => fn($q) => $q->with('user', 'media'),
         ])
         ->whereIn('user_id', $followingIds)
+        ->whereNotIn('user_id', $blockedIds)
         ->latest()
         ->paginate(10, ['*'], 'followed_page');
 
@@ -36,6 +38,7 @@ class DashboardController extends Controller
     ->whereHas('user', function ($query) {
         $query->where('is_private', false);
     })
+    ->whereNotIn('user_id', $blockedIds)
     ->latest()
     ->paginate(10, ['*'], 'explorer_page');
 

--- a/app/Http/Controllers/HashtagController.php
+++ b/app/Http/Controllers/HashtagController.php
@@ -12,16 +12,23 @@ class HashtagController extends Controller
 {
     $hashtag = '#' . $name;
 
-    $posts = Post::with([
+    $authUser = auth()->user();
+
+    $postsQuery = Post::with([
             'user',
             'media',
             'likes',
             'repost' => fn($q) => $q->with('user', 'media'),
         ])
         ->where('content', 'like', "%$hashtag%")
-        ->latest()
-        ->paginate(10)
-        ->withQueryString();
+        ->latest();
+
+    if ($authUser) {
+        $blockedIds = $authUser->blockedIds()->merge($authUser->blockedByIds());
+        $postsQuery->whereNotIn('user_id', $blockedIds);
+    }
+
+    $posts = $postsQuery->paginate(10)->withQueryString();
    $operators = ['+', '-', '*', '/'];
 $a = rand(1, 10);
 $b = rand(1, 10);

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -51,4 +51,15 @@ public function getUserNotifications()
 
         return response()->json(['success' => true]);
     }
+
+    public function markAllAsRead()
+    {
+        $user = auth()->user();
+
+        Notification::where('user_id', $user->id)
+            ->where('read', false)
+            ->update(['read' => true]);
+
+        return response()->json(['success' => true]);
+    }
 }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
 use Inertia\Response;
 use App\Models\User;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class ProfileController extends Controller
 {
@@ -27,6 +28,10 @@ class ProfileController extends Controller
         return Inertia::render('Profile/Edit', [
             'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
             'status' => session('status'),
+            'blockedUsers' => $request->user()
+                ->blocks()
+                ->select('users.id as id', 'users.name', 'users.username', 'users.avatar')
+                ->get(),
         ]);
     }
 
@@ -163,16 +168,24 @@ class ProfileController extends Controller
         ]);
     }
 
-    $posts = $user->posts()
-        ->with([
-            'media',
-            'likes',
-            'user',
-            'repost' => fn($q) => $q->with('user', 'media'),
-        ])
-        ->latest()
-        ->paginate(5)
-        ->withQueryString();
+    $isBlocked = $authUser ? $authUser->hasBlocked($user) : false;
+    $isBlockedBy = $authUser ? $user->hasBlocked($authUser) : false;
+
+    $posts = collect([]);
+    if (!$isBlocked && !$isBlockedBy) {
+        $posts = $user->posts()
+            ->with([
+                'media',
+                'likes',
+                'user',
+                'repost' => fn($q) => $q->with('user', 'media'),
+            ])
+            ->latest()
+            ->paginate(5)
+            ->withQueryString();
+    } else {
+        $posts = new LengthAwarePaginator([], 0, 5);
+    }
     $operators = ['+', '-', '*', '/'];
 $a = rand(1, 10);
 $b = rand(1, 10);
@@ -211,6 +224,8 @@ $captchaAnswer = eval("return $captchaQuestion;");
         'posts' => $posts,
         'isOwner' => $isOwner,
         'isFollowing' => $authUser ? $authUser->isFollowing($user) : false,
+        'isBlocked' => $isBlocked,
+        'isBlockedBy' => $isBlockedBy,
                'captcha' => [
         'question' => $captchaQuestion,
         'answer' => $captchaAnswer,
@@ -263,7 +278,10 @@ $captchaAnswer = eval("return $captchaQuestion;");
         abort(403);
     }
 
-    $followers = $user->followers()->paginate(20);
+    $blockedIds = $user->blockedIds()->merge($user->blockedByIds());
+    $followers = $user->followers()
+        ->whereNotIn('users.id', $blockedIds)
+        ->paginate(20);
 
     return Inertia::render('Profile/Followers', [
         'user' => $user,
@@ -279,7 +297,10 @@ public function following($username)
         abort(403);
     }
 
-    $following = $user->following()->paginate(20);
+    $blockedIds = $user->blockedIds()->merge($user->blockedByIds());
+    $following = $user->following()
+        ->whereNotIn('users.id', $blockedIds)
+        ->paginate(20);
 
     return Inertia::render('Profile/Following', [
         'user' => $user,

--- a/app/Http/Controllers/RootController.php
+++ b/app/Http/Controllers/RootController.php
@@ -14,7 +14,9 @@ class RootController extends Controller
     $query = User::query();
 
     if ($authUser) {
-        $query->where('id', '!=', $authUser->id);
+        $blockedIds = $authUser->blockedIds()->merge($authUser->blockedByIds());
+        $query->where('id', '!=', $authUser->id)
+            ->whereNotIn('id', $blockedIds);
     }
 
     if ($search = $request->search) {

--- a/app/Models/Block.php
+++ b/app/Models/Block.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Block extends Model
+{
+    protected $fillable = ['user_id', 'blocked_id'];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -93,6 +93,38 @@ class User extends Authenticatable
                     ->withTimestamps();
     }
 
+    public function blocks()
+    {
+        return $this->belongsToMany(User::class, 'blocks', 'user_id', 'blocked_id')
+            ->withTimestamps();
+    }
+
+    public function blockedBy()
+    {
+        return $this->belongsToMany(User::class, 'blocks', 'blocked_id', 'user_id')
+            ->withTimestamps();
+    }
+
+    public function hasBlocked(User $user)
+    {
+        return $this->blocks()->where('blocked_id', $user->id)->exists();
+    }
+
+    public function isBlockedBy(User $user)
+    {
+        return $this->blockedBy()->where('user_id', $user->id)->exists();
+    }
+
+    public function blockedIds()
+    {
+        return $this->blocks()->pluck('users.id');
+    }
+
+    public function blockedByIds()
+    {
+        return $this->blockedBy()->pluck('users.id');
+    }
+
 
 
 

--- a/database/migrations/2025_06_07_000000_create_blocks_table.php
+++ b/database/migrations/2025_06_07_000000_create_blocks_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('blocks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('blocked_id')->constrained('users')->onDelete('cascade');
+            $table->timestamps();
+            $table->unique(['user_id', 'blocked_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('blocks');
+    }
+};

--- a/database/seeders/LanguageSeeder.php
+++ b/database/seeders/LanguageSeeder.php
@@ -347,6 +347,12 @@ class LanguageSeeder extends Seeder
             'loading' => ['en' => 'Loading', 'fa' => 'در حال بارگذاری'],
             'back_to_top' => ['en' => 'Back to Top', 'fa' => 'بازگشت به بالا'],
             'retry' => ['en' => 'Retry', 'fa' => 'تلاش مجدد'],
+            'blocked_users' => ['en' => 'Blocked Users', 'fa' => 'کاربران مسدود شده'],
+            'block' => ['en' => 'Block', 'fa' => 'مسدود کردن'],
+            'unblock' => ['en' => 'Unblock', 'fa' => 'رفع مسدودی'],
+            'no_blocked_users' => ['en' => 'No blocked users', 'fa' => 'کاربر مسدودی وجود ندارد'],
+            'you_blocked_this_user' => ['en' => 'You have blocked this user.', 'fa' => 'شما این کاربر را مسدود کرده‌اید.'],
+            'user_has_blocked_you' => ['en' => 'This user has blocked you.', 'fa' => 'این کاربر شما را مسدود کرده است.'],
 
         ];
 

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -4,4 +4,10 @@ return [
     'welcome' => 'Welcome to our site!',
     'login' => 'Login',
     'register' => 'Register',
+    'blocked_users' => 'Blocked Users',
+    'block' => 'Block',
+    'unblock' => 'Unblock',
+    'no_blocked_users' => 'No blocked users',
+    'you_blocked_this_user' => 'You have blocked this user.',
+    'user_has_blocked_you' => 'This user has blocked you.',
 ];

--- a/lang/fa/messages.php
+++ b/lang/fa/messages.php
@@ -4,4 +4,10 @@ return [
     'welcome' => 'به سایت ما خوش آمدید!',
     'login' => 'ورود',
     'register' => 'ثبت نام',
+    'blocked_users' => 'کاربران مسدود شده',
+    'block' => 'مسدود کردن',
+    'unblock' => 'رفع مسدودی',
+    'no_blocked_users' => 'کاربر مسدودی وجود ندارد',
+    'you_blocked_this_user' => 'شما این کاربر را مسدود کرده‌اید.',
+    'user_has_blocked_you' => 'این کاربر شما را مسدود کرده است.',
 ];

--- a/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -45,6 +45,12 @@ const handleFollowAction = (followerId, action, notifId) => {
         });
     };
 
+    const markAllAsRead = () => {
+        axios.post('/notifications/read-all').then(() => {
+            fetchNotifications();
+        });
+    };
+
     const MenuLink = ({ href, active, icon, children }) => (
         <Link
             href={href}
@@ -248,6 +254,11 @@ const handleFollowAction = (followerId, action, notifId) => {
 
 {showNotifications && (
     <div className="absolute right-0 mt-2 w-80 bg-white border border-gray-200 shadow-lg rounded-md z-50 max-h-96 overflow-y-auto">
+        <div className="flex justify-end p-2 border-b">
+            <button onClick={markAllAsRead} className="text-xs text-blue-600 hover:underline">
+                Mark all as read
+            </button>
+        </div>
         {notifications.length === 0 ? (
             <div className="p-4 text-sm text-gray-500 text-center">
                 {t('No notifications available')}

--- a/resources/js/Layouts/AuthenticatedLayoutAdmin.jsx
+++ b/resources/js/Layouts/AuthenticatedLayoutAdmin.jsx
@@ -36,6 +36,12 @@ export default function AuthenticatedLayout({ header, children }) {
         });
     };
 
+    const markAllAsRead = () => {
+        axios.post('/notifications/read-all').then(() => {
+            fetchNotifications();
+        });
+    };
+
     return (
         <div className="min-h-screen bg-gray-100">
             <nav className="border-b border-gray-100 bg-white">
@@ -77,6 +83,11 @@ export default function AuthenticatedLayout({ header, children }) {
 
                                 {showNotifications && (
                                     <div className="absolute right-0 mt-2 w-80 bg-white border border-gray-200 shadow-lg rounded-md z-50 max-h-96 overflow-y-auto">
+                                        <div className="flex justify-end p-2 border-b">
+                                            <button onClick={markAllAsRead} className="text-xs text-blue-600 hover:underline">
+                                                Mark all as read
+                                            </button>
+                                        </div>
                                         {notifications.length === 0 ? (
                                             <div className="p-4 text-sm text-gray-500 text-center">هیچ نوتیفیکیشنی وجود ندارد</div>
                                         ) : (

--- a/resources/js/Pages/Profile/Edit.jsx
+++ b/resources/js/Pages/Profile/Edit.jsx
@@ -8,9 +8,10 @@ import UpdateProfileInformationForm from './Partials/UpdateProfileInformationFor
 import UpdateAvatarCoverForm from './Partials/UpdateAvatarCoverForm';
 import Links from './Partials/Links';
 import NotificationSettingsForm from './Partials/NotificationSettingsForm';
+import BlockedUsers from './Partials/BlockedUsers';
 import { useTranslation } from 'react-i18next';
 
-export default function Edit({ mustVerifyEmail, status, auth }) {
+export default function Edit({ mustVerifyEmail, status, auth, blockedUsers }) {
     const [activeTab, setActiveTab] = useState('profile');
     const { t } = useTranslation();
 
@@ -20,6 +21,7 @@ export default function Edit({ mustVerifyEmail, status, auth }) {
         { name: t('links'), key: 'links' },
         { name: t('password'), key: 'password' },
         { name: t('notifications'), key: 'notifications' },
+        { name: t('blocked_users'), key: 'blocks' },
         { name: t('delete_account'), key: 'delete' },
     ];
 
@@ -41,6 +43,8 @@ export default function Edit({ mustVerifyEmail, status, auth }) {
                 return <UpdatePasswordForm className="max-w-xl" />;
             case 'notifications':
                 return <NotificationSettingsForm user={auth.user} />;
+            case 'blocks':
+                return <BlockedUsers blockedUsers={blockedUsers} />;
             case 'delete':
                 return <DeleteUserForm className="max-w-xl" />;
             default:

--- a/resources/js/Pages/Profile/Partials/BlockedUsers.jsx
+++ b/resources/js/Pages/Profile/Partials/BlockedUsers.jsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import axios from 'axios';
+import { useTranslation } from 'react-i18next';
+
+export default function BlockedUsers({ blockedUsers }) {
+    const { t } = useTranslation();
+    const [users, setUsers] = useState(blockedUsers);
+
+    const handleUnblock = (username) => {
+        axios.delete(route('user.unblock', username)).then(() => {
+            setUsers(users.filter((u) => u.username !== username));
+        });
+    };
+
+    if (!users.length) {
+        return <p className="text-sm text-gray-600">{t('no_blocked_users')}</p>;
+    }
+
+    return (
+        <div className="space-y-4">
+            {users.map((u) => (
+                <div key={u.id} className="flex items-center justify-between border-b pb-2">
+                    <div className="flex items-center space-x-4">
+                        <img src={u.avatar ? `/storage/${u.avatar}` : '/default-avatar.png'} alt="avatar" className="w-10 h-10 rounded-full" />
+                        <div>
+                            <p className="font-semibold">{u.name}</p>
+                            <p className="text-sm text-gray-500">@{u.username}</p>
+                        </div>
+                    </div>
+                    <button onClick={() => handleUnblock(u.username)} className="px-3 py-1 text-xs bg-red-500 text-white rounded">
+                        {t('unblock')}
+                    </button>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\ReportController;
 use App\Http\Controllers\LikeController;
 use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\FollowController;
+use App\Http\Controllers\BlockController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\HashtagController;
 use App\Http\Controllers\MessageReactionController;
@@ -86,10 +87,14 @@ Route::middleware('auth')->group(function () {
     Route::post('/ajax/follow/{user:username}', [FollowController::class, 'ajaxToggle'])->name('follow.ajax');
     Route::post('/ajax/remove-follower/{user:username}', [FollowController::class, 'removeFollower'])->name('follow.remove_follower');
 
+    Route::post('/block/{user:username}', [BlockController::class, 'block'])->name('user.block');
+    Route::delete('/block/{user:username}', [BlockController::class, 'unblock'])->name('user.unblock');
+
     Route::post('/follow/{user}/accept', [FollowController::class, 'acceptRequest'])->name('follow.accept');
     Route::post('/follow/{user}/reject', [FollowController::class, 'rejectRequest'])->name('follow.reject');
     Route::get('/notifications', [NotificationController::class, 'getUserNotifications']);
     Route::post('/notifications/read/{id}', [NotificationController::class, 'markAsRead']);
+    Route::post('/notifications/read-all', [NotificationController::class, 'markAllAsRead']);
     Route::post('/username-check', function (Request $request) {
         $request->validate([
             'username' => 'required|string|min:4|max:222',


### PR DESCRIPTION
## Summary
- hide posts from blocked or blocking users throughout the app
- add helpers on `User` model for blocked ID lists
- filter followed/explorer feeds and hashtags using these lists
- exclude blocked accounts from user, follower, and following lists
- prevent viewing posts when a block exists

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b9054f108326a135055502d65e10