### PR TITLE
Add auto installer check

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,29 +75,41 @@ cp .env.example .env
 
 Then update your `.env` file with your database credentials and other necessary configurations.
 
-### 5. Generate Application Key
+### 5. Run the Web Installer
+
+Start the development server and navigate to `/install` relative to your application's base URL. The installer will collect your database details, run migrations and seeders, and create the admin account automatically.
+
+```bash
+php artisan serve
+```
+
+For example, if you're running the app at `http://localhost:8000` visit `http://localhost:8000/install`. When serving from a subdirectory like `http://localhost/folder`, open `http://localhost/folder/install`.
+
+If you prefer manual setup, continue with the steps below.
+
+### 6. Generate Application Key
 
 ```bash
 php artisan key:generate
 ```
 
-### 6. Run Database Migrations
+### 7. Run Database Migrations
 
 ```bash
 php artisan migrate
 ```
 
-### 7. Seed the Database
+### 8. Seed the Database
 
 ```bash
 php artisan db:seed
 ```
 
-### 8. Set Admin Privileges
+### 9. Set Admin Privileges
 
 After seeding, go to the `users` table and set `is_admin = 1` for your user manually.
 
-### 9. Serve the Application
+### 10. Serve the Application
 
 ```bash
 php artisan serve
@@ -109,7 +121,7 @@ The application will be available at:
 http://localhost:8000
 ```
 
-### 10. Build Frontend Assets
+### 11. Build Frontend Assets
 
 For development:
 

--- a/app/Http/Controllers/InstallController.php
+++ b/app/Http/Controllers/InstallController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\File;
+use App\Models\User;
+
+class InstallController extends Controller
+{
+    public function show()
+    {
+        if (File::exists(storage_path('installed'))) {
+            return redirect()->route('welcome');
+        }
+        return inertia('Install');
+    }
+
+    public function install(Request $request)
+    {
+        $request->validate([
+            'db_host' => 'required',
+            'db_port' => 'required',
+            'db_database' => 'required',
+            'db_username' => 'required',
+            'admin_name' => 'required',
+            'admin_email' => 'required|email',
+            'admin_username' => 'required',
+            'admin_password' => 'required',
+        ]);
+
+        $envPath = base_path('.env');
+        $env = File::exists($envPath) ? File::get($envPath) : File::get(base_path('.env.example'));
+
+        $env = preg_replace('/DB_HOST=.*/', 'DB_HOST='.$request->db_host, $env);
+        $env = preg_replace('/DB_PORT=.*/', 'DB_PORT='.$request->db_port, $env);
+        $env = preg_replace('/DB_DATABASE=.*/', 'DB_DATABASE='.$request->db_database, $env);
+        $env = preg_replace('/DB_USERNAME=.*/', 'DB_USERNAME='.$request->db_username, $env);
+        $env = preg_replace('/DB_PASSWORD=.*/', 'DB_PASSWORD='.$request->db_password, $env);
+
+        File::put($envPath, $env);
+
+        config([
+            'database.connections.mysql.host' => $request->db_host,
+            'database.connections.mysql.port' => $request->db_port,
+            'database.connections.mysql.database' => $request->db_database,
+            'database.connections.mysql.username' => $request->db_username,
+            'database.connections.mysql.password' => $request->db_password,
+        ]);
+        DB::purge('mysql');
+
+        Artisan::call('key:generate', ['--force' => true]);
+        Artisan::call('config:clear');
+
+        config([
+            'database.connections.installer' => [
+                'driver' => 'mysql',
+                'host' => $request->db_host,
+                'port' => $request->db_port,
+                'username' => $request->db_username,
+                'password' => $request->db_password,
+            ],
+        ]);
+        try {
+            DB::connection('installer')->statement('CREATE DATABASE IF NOT EXISTS `'.$request->db_database.'`');
+        } catch (\Exception $e) {
+            // ignore errors creating database
+        }
+
+        Artisan::call('migrate', ['--force' => true]);
+        Artisan::call('db:seed', ['--force' => true]);
+
+        User::create([
+            'name' => $request->admin_name,
+            'email' => $request->admin_email,
+            'username' => $request->admin_username,
+            'password' => Hash::make($request->admin_password),
+            'is_admin' => true,
+        ]);
+
+        File::put(storage_path('installed'), now()->toDateTimeString());
+
+        return redirect()->route('welcome');
+    }
+}

--- a/app/Http/Middleware/CheckForInstallation.php
+++ b/app/Http/Middleware/CheckForInstallation.php
@@ -5,6 +5,7 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Support\Facades\File;
 
 class CheckForInstallation
 {
@@ -15,10 +16,13 @@ class CheckForInstallation
      */
     public function handle($request, Closure $next)
     {
-        if (config('app.needs_installation') && !$request->is('install*')) {
-            return redirect('/install');
+        $needsInstall = config('database.connections.mysql.database') === 'shz_mobile'
+            && !File::exists(storage_path('installed'));
+
+        if ($needsInstall && !$request->is('install*')) {
+            return redirect()->route('install.show');
         }
-    
+
         return $next($request);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -15,7 +15,7 @@ return Application::configure(basePath: dirname(__DIR__))
             \App\Http\Middleware\HandleInertiaRequests::class,
             \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,
             \App\Http\Middleware\SetLocale::class, // 👈 این خط رو اضافه کردم
-            // \App\Http\Middleware\CheckForInstallation::class,
+            \App\Http\Middleware\CheckForInstallation::class,
             \App\Http\Middleware\VerifyCsrfToken::class, 
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ]);

--- a/resources/js/Pages/Install.jsx
+++ b/resources/js/Pages/Install.jsx
@@ -1,0 +1,82 @@
+import InputError from '@/Components/InputError';
+import InputLabel from '@/Components/InputLabel';
+import PrimaryButton from '@/Components/PrimaryButton';
+import TextInput from '@/Components/TextInput';
+import GuestLayout from '@/Layouts/GuestLayout';
+import { Head, useForm } from '@inertiajs/react';
+
+export default function Install() {
+    const { data, setData, post, processing, errors } = useForm({
+        db_host: '127.0.0.1',
+        db_port: '3306',
+        db_database: '',
+        db_username: '',
+        db_password: '',
+        admin_name: '',
+        admin_email: '',
+        admin_username: '',
+        admin_password: '',
+    });
+
+    const submit = (e) => {
+        e.preventDefault();
+        post(route('install.perform'));
+    };
+
+    return (
+        <GuestLayout>
+            <Head title="Install" />
+            <form onSubmit={submit} className="space-y-4">
+                <h2 className="text-xl font-semibold">Database</h2>
+                <div>
+                    <InputLabel htmlFor="db_host" value="DB Host" />
+                    <TextInput id="db_host" name="db_host" value={data.db_host} className="mt-1 block w-full" onChange={e => setData('db_host', e.target.value)} required />
+                    <InputError message={errors.db_host} className="mt-2" />
+                </div>
+                <div>
+                    <InputLabel htmlFor="db_port" value="DB Port" />
+                    <TextInput id="db_port" name="db_port" value={data.db_port} className="mt-1 block w-full" onChange={e => setData('db_port', e.target.value)} required />
+                    <InputError message={errors.db_port} className="mt-2" />
+                </div>
+                <div>
+                    <InputLabel htmlFor="db_database" value="DB Database" />
+                    <TextInput id="db_database" name="db_database" value={data.db_database} className="mt-1 block w-full" onChange={e => setData('db_database', e.target.value)} required />
+                    <InputError message={errors.db_database} className="mt-2" />
+                </div>
+                <div>
+                    <InputLabel htmlFor="db_username" value="DB Username" />
+                    <TextInput id="db_username" name="db_username" value={data.db_username} className="mt-1 block w-full" onChange={e => setData('db_username', e.target.value)} required />
+                    <InputError message={errors.db_username} className="mt-2" />
+                </div>
+                <div>
+                    <InputLabel htmlFor="db_password" value="DB Password" />
+                    <TextInput id="db_password" type="password" name="db_password" value={data.db_password} className="mt-1 block w-full" onChange={e => setData('db_password', e.target.value)} />
+                    <InputError message={errors.db_password} className="mt-2" />
+                </div>
+
+                <h2 className="text-xl font-semibold pt-4">Admin User</h2>
+                <div>
+                    <InputLabel htmlFor="admin_name" value="Name" />
+                    <TextInput id="admin_name" name="admin_name" value={data.admin_name} className="mt-1 block w-full" onChange={e => setData('admin_name', e.target.value)} required />
+                    <InputError message={errors.admin_name} className="mt-2" />
+                </div>
+                <div>
+                    <InputLabel htmlFor="admin_email" value="Email" />
+                    <TextInput id="admin_email" type="email" name="admin_email" value={data.admin_email} className="mt-1 block w-full" onChange={e => setData('admin_email', e.target.value)} required />
+                    <InputError message={errors.admin_email} className="mt-2" />
+                </div>
+                <div>
+                    <InputLabel htmlFor="admin_username" value="Username" />
+                    <TextInput id="admin_username" name="admin_username" value={data.admin_username} className="mt-1 block w-full" onChange={e => setData('admin_username', e.target.value)} required />
+                    <InputError message={errors.admin_username} className="mt-2" />
+                </div>
+                <div>
+                    <InputLabel htmlFor="admin_password" value="Password" />
+                    <TextInput id="admin_password" type="password" name="admin_password" value={data.admin_password} className="mt-1 block w-full" onChange={e => setData('admin_password', e.target.value)} required />
+                    <InputError message={errors.admin_password} className="mt-2" />
+                </div>
+                <PrimaryButton disabled={processing}>Install</PrimaryButton>
+            </form>
+        </GuestLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\RootController;
 use App\Http\Controllers\StatisticController;
 use App\Http\Controllers\LanguageController;
 use App\Http\Controllers\TranslationController;
+use App\Http\Controllers\InstallController;
 use Illuminate\Http\Request;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
@@ -39,6 +40,9 @@ Route::get('/', function () {
         'phpVersion' => PHP_VERSION,
     ]);
 })->name('welcome');
+
+Route::get('/install', [InstallController::class, 'show'])->name('install.show');
+Route::post('/install', [InstallController::class, 'install'])->name('install.perform');
 
 
 Route::get('/manifest.json', [PwaController::class, 'manifest'])->name('pwa.manifest');


### PR DESCRIPTION
## Summary
- enable installation middleware
- redirect to `/install` if the default DB name is still in use
- update installer to apply DB settings immediately
- ensure redirects use named routes so subdirectory installs work

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647e9923dc8326a8414109f771c19c