### PR TITLE
Fix install URL when app is in subdirectory

### DIFF
--- a/app/Http/Middleware/CheckForInstallation.php
+++ b/app/Http/Middleware/CheckForInstallation.php
@@ -20,7 +20,10 @@ class CheckForInstallation
             && !File::exists(storage_path('installed'));
 
         if ($needsInstall && !$request->is('*install*')) {
-            return redirect($request->root().'/install');
+            // Build the install URL using the scheme, host, and base path
+            // so that nested subdirectory deployments redirect correctly.
+            $installUrl = $request->getSchemeAndHttpHost().$request->getBasePath().'/install';
+            return redirect()->to($installUrl);
         }
 
         return $next($request);


### PR DESCRIPTION
## Summary
- correct installation redirect when the app runs from a subdirectory

## Testing
- `php -l app/Http/Middleware/CheckForInstallation.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864bc517d088326bd9128e7b0b987fb