### PR TITLE
Update login/register colors

### DIFF
--- a/resources/js/Layouts/GuestLayout.jsx
+++ b/resources/js/Layouts/GuestLayout.jsx
@@ -73,7 +73,7 @@ export default function GuestLayout({ children }) {
                 {/* Footer Text */}
                 <div className="mt-12 text-center">
                     <p className="text-sm text-gray-600 dark:text-gray-400 font-medium">
-                        Welcome to our platform
+                        {import.meta.env.VITE_APP_NAME}
                     </p>
                     <div className="flex items-center justify-center space-x-2 mt-2">
                         <div className="w-2 h-2 bg-indigo-500 rounded-full animate-pulse"></div>

--- a/resources/js/Pages/Auth/Login.jsx
+++ b/resources/js/Pages/Auth/Login.jsx
@@ -91,7 +91,7 @@ export default function Login({ status, canResetPassword }) {
                 </div>
 
                 <div className="mt-4 flex items-center justify-between flex-wrap gap-2">
-                    <div className="text-sm text-gray-600">
+                    <div className="text-sm text-white">
                         {t('dont_have_account')}{' '}
                         <Link
                             href={route('register')}
@@ -105,7 +105,7 @@ export default function Login({ status, canResetPassword }) {
                         {canResetPassword && (
                             <Link
                                 href={route('password.request')}
-                                className="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                                className="rounded-md text-sm text-white underline hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
                             >
                                 {t('forgot_password')}
                             </Link>

--- a/resources/js/Pages/Auth/Register.jsx
+++ b/resources/js/Pages/Auth/Register.jsx
@@ -120,7 +120,7 @@ export default function Register() {
                 <div className="mt-4 flex items-center justify-end">
                     <Link
                         href={route('login')}
-                        className="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                        className="rounded-md text-sm text-white underline hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
                     >
                         {t('already_registered')}
                     </Link>


### PR DESCRIPTION
## Summary
- use app name in GuestLayout footer
- make login/register link text white

## Testing
- `php artisan test` *(fails: vendor dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e6c73804883269e3f025cc3478cf8