### PR TITLE
Set categories header to white

### DIFF
--- a/resources/js/Pages/UserPages/Index.jsx
+++ b/resources/js/Pages/UserPages/Index.jsx
@@ -53,7 +53,7 @@ export default function Index({ pages, filters, categories }) {
         )}
 
         <div className="mt-8">
-          <h3 className="font-semibold mb-2">{t('categories')}</h3>
+          <h3 className="font-semibold text-white mb-2">{t('categories')}</h3>
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
             {Object.entries(categories).map(([group, cats]) => (
               <div key={group}>


### PR DESCRIPTION
## Summary
- make the "Categories" heading white on the /pages screen

## Testing
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e73a5ad988326abefd818a1bbdb38