### PR TITLE
Fix install page for unconfigured DB

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -5,6 +5,7 @@ namespace App\Http\Middleware;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\File;
 use App\Helpers\PageHelper;
 
 class HandleInertiaRequests extends Middleware
@@ -39,7 +40,9 @@ class HandleInertiaRequests extends Middleware
             'flash' => [
             'success' => fn () => $request->session()->get('success'),
           ],
-          'pagesByLang' => fn () => PageHelper::getPagesByLocale(),
+          'pagesByLang' => fn () => File::exists(storage_path('installed'))
+                ? PageHelper::getPagesByLocale()
+                : [],
         ];
     }
 }


### PR DESCRIPTION
## Summary
- avoid database queries when app is not yet installed

## Testing
- `composer test` *(fails: composer not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea1c7ec988326a63a12228d19d528