### PR TITLE
Fix symlink creation without exec

### DIFF
--- a/app/Http/Controllers/InstallController.php
+++ b/app/Http/Controllers/InstallController.php
@@ -76,8 +76,8 @@ class InstallController extends Controller
         $storageLink = public_path('storage');
         if (!File::exists($storageLink)) {
             try {
-                File::link(storage_path('app/public'), $storageLink);
-            } catch (\Exception $e) {
+                @symlink(storage_path('app/public'), $storageLink);
+            } catch (\Throwable $e) {
                 Artisan::call('storage:link');
             }
         }


### PR DESCRIPTION
## Summary
- avoid `File::link` so envs without exec() still work

## Testing
- `php -d detect_unicode=0 ./vendor/bin/phpunit --stop-on-failure` *(fails: Could not open input file)*

------
https://chatgpt.com/codex/tasks/task_e_687eace9eddc83268240fe11ca5756c7