### PR TITLE
Fix storage link creation when exec is disabled

### DIFF
--- a/app/Http/Controllers/InstallController.php
+++ b/app/Http/Controllers/InstallController.php
@@ -78,7 +78,11 @@ class InstallController extends Controller
             try {
                 @symlink(storage_path('app/public'), $storageLink);
             } catch (\Throwable $e) {
-                Artisan::call('storage:link');
+                if (function_exists('exec')) {
+                    Artisan::call('storage:link');
+                } else {
+                    File::copyDirectory(storage_path('app/public'), $storageLink);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid calling `storage:link` when PHP `exec` is disabled
- fallback to copy files instead of using `exec`

## Testing
- `composer test` *(fails: vendor not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687eaff4085483269a202969f05b4dac