### PR TITLE
Display admin credentials after install

### DIFF
--- a/app/Http/Controllers/InstallController.php
+++ b/app/Http/Controllers/InstallController.php
@@ -90,4 +90,14 @@ class InstallController extends Controller
 
         return inertia('Installed');
     }
+
+    public function deleteInstallFile()
+    {
+        $installed = storage_path('installed');
+        if (File::exists($installed)) {
+            File::delete($installed);
+        }
+
+        return redirect()->route('install.show');
+    }
 }

--- a/resources/js/Pages/Installed.jsx
+++ b/resources/js/Pages/Installed.jsx
@@ -1,13 +1,25 @@
 import GuestLayout from '@/Layouts/GuestLayout';
-import { Head } from '@inertiajs/react';
+import PrimaryButton from '@/Components/PrimaryButton';
+import { Head, useForm } from '@inertiajs/react';
 
 export default function Installed() {
+    const { post, processing } = useForm({});
+
+    const removeFile = (e) => {
+        e.preventDefault();
+        post(route('install.delete-file'));
+    };
+
     return (
         <GuestLayout>
             <Head title="Installed" />
             <div className="text-center py-10 text-white">
                 <h1 className="text-2xl font-bold mb-4">Installation Complete</h1>
-                <p>Admin username and password: <strong>admin@admin.com</strong></p>
+                <p className="mb-2">Admin email: <strong>admin@admin.com</strong></p>
+                <p>Admin password: <strong>admin@admin.com</strong></p>
+                <form onSubmit={removeFile} className="mt-6">
+                    <PrimaryButton disabled={processing}>Delete install file</PrimaryButton>
+                </form>
             </div>
         </GuestLayout>
     );

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,7 @@ Route::get('/', function () {
 
 Route::get('/install', [InstallController::class, 'show'])->name('install.show');
 Route::post('/install', [InstallController::class, 'install'])->name('install.perform');
+Route::post('/install/delete-file', [InstallController::class, 'deleteInstallFile'])->name('install.delete-file');
 
 
 Route::get('/manifest.json', [PwaController::class, 'manifest'])->name('pwa.manifest');


### PR DESCRIPTION
## Summary
- show admin email and password on the Installed page
- offer button to delete the installation file
- handle deletion in controller and add route

## Testing
- `composer test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687eb25e1d28832685001c66f5b900b5