### PR TITLE
Fix install delete file 419

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -8,5 +8,6 @@ class VerifyCsrfToken extends Middleware
 {
     protected $except = [
         '/install', // Exclude install from CSRF check
+        '/install/delete-file', // Allow delete install file without CSRF
     ];
 }


### PR DESCRIPTION
## Summary
- add `/install/delete-file` to CSRF middleware exceptions

## Testing
- `php artisan test` *(fails: vendor not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687ebbad31e88326900cfd954fc199c7