### PR TITLE
Fix CSRF installer path

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -7,7 +7,6 @@ use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
 class VerifyCsrfToken extends Middleware
 {
     protected $except = [
-        '/install', // Exclude install from CSRF check
-        '/install/delete-file', // Allow delete install file without CSRF
+        '*install*', // Allow installer routes regardless of subdirectory
     ];
 }


### PR DESCRIPTION
## Summary
- allow installer routes to bypass CSRF checks even when app is in a subdirectory

## Testing
- `composer test` *(fails: vendor packages missing due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_687ebead65308326b893f8f63cadf83e