### PR TITLE
Disable install route after setup

### DIFF
--- a/app/Http/Controllers/InstallController.php
+++ b/app/Http/Controllers/InstallController.php
@@ -12,7 +12,7 @@ class InstallController extends Controller
     public function show(Request $request)
     {
         if (File::exists(storage_path('installed'))) {
-            return inertia('Installed');
+            return redirect()->route('welcome');
         }
         return inertia('Install');
     }
@@ -91,13 +91,4 @@ class InstallController extends Controller
         return inertia('Installed');
     }
 
-    public function deleteInstallFile()
-    {
-        $installed = storage_path('installed');
-        if (File::exists($installed)) {
-            File::delete($installed);
-        }
-
-        return redirect()->route('install.show');
-    }
 }

--- a/resources/js/Pages/Installed.jsx
+++ b/resources/js/Pages/Installed.jsx
@@ -1,14 +1,7 @@
 import GuestLayout from '@/Layouts/GuestLayout';
-import PrimaryButton from '@/Components/PrimaryButton';
-import { Head, useForm } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
 
 export default function Installed() {
-    const { post, processing } = useForm({});
-
-    const removeFile = (e) => {
-        e.preventDefault();
-        post(route('install.delete-file'));
-    };
 
     return (
         <GuestLayout>
@@ -18,9 +11,14 @@ export default function Installed() {
                 <p className="mb-2">Admin email: <strong>admin@admin.com</strong></p>
                 <p>Admin password: <strong>admin@admin.com</strong></p>
                 <p className="mb-6">Please change <strong>your email and password</strong> after logging in.</p>
-                <form onSubmit={removeFile} className="mt-6">
-                    <PrimaryButton disabled={processing}>Delete install file</PrimaryButton>
-                </form>
+                <div className="mt-6">
+                    <Link
+                        href="/"
+                        className="inline-flex items-center rounded-md border border-gray-300 bg-gray-800 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-gray-700 focus:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                    >
+                        Show your website
+                    </Link>
+                </div>
             </div>
         </GuestLayout>
     );

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\StatisticController;
 use App\Http\Controllers\LanguageController;
 use App\Http\Controllers\TranslationController;
 use App\Http\Controllers\InstallController;
+use Illuminate\Support\Facades\File;
 use Illuminate\Http\Request;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
@@ -40,9 +41,10 @@ Route::get('/', function () {
     ]);
 })->name('welcome');
 
-Route::get('/install', [InstallController::class, 'show'])->name('install.show');
-Route::post('/install', [InstallController::class, 'install'])->name('install.perform');
-Route::post('/install/delete-file', [InstallController::class, 'deleteInstallFile'])->name('install.delete-file');
+if (!File::exists(storage_path('installed'))) {
+    Route::get('/install', [InstallController::class, 'show'])->name('install.show');
+    Route::post('/install', [InstallController::class, 'install'])->name('install.perform');
+}
 
 
 Route::get('/manifest.json', [PwaController::class, 'manifest'])->name('pwa.manifest');


### PR DESCRIPTION
## Summary
- redirect /install to the home page when already installed
- drop delete-install-file route
- link to the main page from the Installed screen

## Testing
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ec294d9cc8326a3ae5a87cce9597b